### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # InspectableLabel
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/InspectableLabel.svg)](https://img.shields.io/cocoapods/v/InspectableLabel.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/InspectableLabel.svg)](https://img.shields.io/cocoapods/v/InspectableLabel.svg)
 [![GitHub license](https://img.shields.io/badge/license-Apache 2.0-lightgrey.svg)](https://raw.githubusercontent.com/indevizible/InspectableLabel/master/LICENSE)
 [![Platform](https://img.shields.io/cocoapods/p/InspectableLabel.svg?style=flat)](http://cocoadocs.org/docsets/InspectableLabel)
 [![Twitter](https://img.shields.io/badge/twitter-@indevizible-blue.svg?style=flat)](http://twitter.com/indevizible)


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
